### PR TITLE
Allow overriding the host used in file urls.

### DIFF
--- a/lib/dato/local/field_type/file.rb
+++ b/lib/dato/local/field_type/file.rb
@@ -21,15 +21,15 @@ module Dato
           @size = size
         end
 
-        def file
+        def file(host = default_host)
           Imgix::Client.new(
-            host: 'dato-images.imgix.net',
+            host: host,
             secure: true
           ).path(path)
         end
 
-        def url(*args)
-          file.to_url(*args)
+        def url(host: default_host, **opts)
+          file(host).to_url(opts)
         end
 
         def to_hash
@@ -39,6 +39,13 @@ module Dato
             url: url
           }
         end
+        
+      private
+      
+        def default_host
+          'dato-images.imgix.net'
+        end
+        
       end
     end
   end

--- a/lib/dato/local/field_type/image.rb
+++ b/lib/dato/local/field_type/image.rb
@@ -23,7 +23,7 @@ module Dato
           @height = height
         end
 
-        def file
+        def file(host = default_host)
           super.ch('DPR', 'Width').auto('compress', 'format')
         end
 

--- a/spec/dato/local/field_type/file_spec.rb
+++ b/spec/dato/local/field_type/file_spec.rb
@@ -23,6 +23,10 @@ module Dato
         it 'responds to url method' do
           expect(file.url(w: 300)).to eq 'https://dato-images.imgix.net/foo.png?ixlib=rb-1.1.0&w=300'
         end
+
+        it 'allows overriding the host' do
+          expect(file.url(host: 'https://images.example.com', w: 300)).to eq 'https://images.example.com/foo.png?ixlib=rb-1.1.0&w=300'
+        end
       end
     end
   end


### PR DESCRIPTION
This is useful if, for example, you're following Imgix's SEO guidelines and setting up a CNAME from `images.example.com` to `dato-images.imgix.net`.