### PR TITLE
Fix dato dump for tree objects

### DIFF
--- a/lib/dato/local/item.rb
+++ b/lib/dato/local/item.rb
@@ -118,8 +118,8 @@ module Dato
 
         if item_type.tree
           base[:position] = position
-          base[:children] = children.map do |_i|
-            value.to_hash(
+          base[:children] = children.map do |child|
+            child.to_hash(
               max_depth,
               current_depth + 1
             )


### PR DESCRIPTION
Int his line, the 'value' variable is not defined, and thus ends up
being a method call grabbed by "method_missing" below. Instead, since
the tree is recursive, we should be calling that method on the child of
the tree.