### PR TITLE
Bug/fallback seo title is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.10
+
+* Fixed SEO title retrieval. Now it fallbacks to default SEO title is item title is blank
+
 # 0.7.9
 
 * Added new attributes to uploads

--- a/lib/dato/utils/meta_tags/base.rb
+++ b/lib/dato/utils/meta_tags/base.rb
@@ -28,7 +28,7 @@ module Dato
           fallback_seo_value = fallback_seo &&
                                fallback_seo.send(attribute)
 
-          item_seo_value || alternative || fallback_seo_value
+          item_seo_value.presence || alternative.presence || fallback_seo_value
         end
 
         def tag(tag_name, attributes)

--- a/lib/dato/version.rb
+++ b/lib/dato/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dato
-  VERSION = '0.7.9'
+  VERSION = '0.7.10'
 end

--- a/spec/dato/utils/meta_tags/title_spec.rb
+++ b/spec/dato/utils/meta_tags/title_spec.rb
@@ -150,6 +150,30 @@ module Dato
                   end
                 end
               end
+
+              context 'with blank title' do
+                let(:item_title) { '' }
+
+                context 'no SEO' do
+                  it 'returns fallback title' do
+                    expect(title_tag).to eq('Default title')
+                    expect(og_value).to eq('Default title')
+                    expect(card_value).to eq('Default title')
+                  end
+                end
+
+                context 'with SEO' do
+                  let(:seo) do
+                    { title: 'SEO title' }
+                  end
+
+                  it 'returns SEO title' do
+                    expect(title_tag).to eq('SEO title')
+                    expect(og_value).to eq('SEO title')
+                    expect(card_value).to eq('SEO title')
+                  end
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
If a SEO field is present in the Item, but the title is blank ( empty string ), we should fallback to the project seo title.

This PR does this :)